### PR TITLE
fix(e2e): three unrelated causes of a permanently red pipeline

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1002,6 +1002,33 @@ p:not([class*='text-']) {
   }
 }
 
+/* Dropdown/menu rows must be tappable (#93 follow-up, WCAG 2.5.5).
+ *
+ * DaisyUI's `.menu-sm` sizes rows as `font-size: .75rem` with
+ * `padding-block: .25rem`, so a row is 12px x 1.5 line-height + 8px = 26px.
+ * That is what CI caught: `Button 8 "Sign Out": height 26.0px < 44px`, on the
+ * primary destructive action, at 390px.
+ *
+ * Fixed here rather than per-element for two reasons:
+ *   1. There are two byte-identical Sign Out buttons (GlobalNav.tsx:333 and
+ *      :441). The touch-target gate only opens the mobile menu, so it can
+ *      never see the account-dropdown twin — a markup fix would leave a
+ *      known-broken control shipping and untested.
+ *   2. Every OTHER row in those menus is 26px too (Profile, Account Settings,
+ *      Companies, Messages, Connections). They are plain anchors, which the
+ *      gate's selector excludes under the WCAG-2.2 inline-link exemption —
+ *      an exemption that does not apply to menu rows. Patching only the
+ *      button would leave one 44px row among six 26px ones: worse-looking
+ *      and still non-compliant.
+ *
+ * `:where()` keeps specificity at 0 so utilities and explicit heights still
+ * win. Scoped to `li` children so the `.menu.card` content panels that hold
+ * arbitrary markup (FontSwitcher) are untouched. */
+.menu :where(li:not(.menu-title)) > :where(a, button) {
+  min-height: 2.75rem; /* 44px */
+  align-content: center;
+}
+
 /* Global Typography Scale (Mobile-first) */
 /* Ensures consistent heading sizes across all pages */
 

--- a/tests/e2e/messaging/complete-user-workflow.spec.ts
+++ b/tests/e2e/messaging/complete-user-workflow.spec.ts
@@ -416,7 +416,7 @@ test.describe('Complete User Messaging Workflow (Feature 024)', () => {
         const safeUserId = escapeSQL(userAId);
         const safeAdminId = escapeSQL(userBId);
         const rows = (await executeSQL(
-          `SELECT id, status, requester_id, addressee_id FROM connections WHERE requester_id = '${safeUserId}' AND addressee_id = '${safeAdminId}' ORDER BY created_at DESC LIMIT 1`
+          `SELECT id, status, requester_id, addressee_id FROM user_connections WHERE requester_id = '${safeUserId}' AND addressee_id = '${safeAdminId}' ORDER BY created_at DESC LIMIT 1`
         )) as {
           id: string;
           status: string;
@@ -498,7 +498,7 @@ test.describe('Complete User Messaging Workflow (Feature 024)', () => {
           const safeUserId = escapeSQL(reqId);
           const safeAdminId = escapeSQL(addrId);
           const dbRows = (await executeSQL(
-            `SELECT id, status FROM connections WHERE requester_id = '${safeUserId}' AND addressee_id = '${safeAdminId}' LIMIT 1`
+            `SELECT id, status FROM user_connections WHERE requester_id = '${safeUserId}' AND addressee_id = '${safeAdminId}' LIMIT 1`
           )) as { id: string; status: string }[];
           dbExists = dbRows.length > 0;
           console.log(

--- a/tests/e2e/messaging/offline-queue.spec.ts
+++ b/tests/e2e/messaging/offline-queue.spec.ts
@@ -118,8 +118,8 @@ test.describe('Offline Message Queue', () => {
       // queue at all.
       //
       // The underlying inability to restore cached keys offline is a real
-      // product bug, tracked separately — this wait establishes the
-      // precondition, it does not paper over that.
+      // product bug, tracked as #96 — this wait establishes the precondition,
+      // it does not paper over that.
       const messageInput = page.locator('textarea[aria-label="Message input"]');
       await expect(messageInput).toBeVisible({ timeout: 30000 });
 

--- a/tests/e2e/messaging/offline-queue.spec.ts
+++ b/tests/e2e/messaging/offline-queue.spec.ts
@@ -101,6 +101,28 @@ test.describe('Offline Message Queue', () => {
       await completeEncryptionSetup(page);
       await dismissReAuthModal(page);
 
+      // Wait for the thread to actually render BEFORE cutting the network.
+      //
+      // Without this the test went offline ~90ms after `goto` resolved —
+      // before hydration. `messages/page.tsx:129-140` then calls
+      // `supabase.auth.getUser()`, a NETWORK round trip, to learn the user id;
+      // offline it returns null, so `restoreKeysFromSession(undefined)` builds
+      // a null storage key and never even looks at the keys injected above.
+      // `hasKeys()` makes a second network call, also fails, and the app
+      // redirects to /messages/setup — whose RSC payload cannot be fetched
+      // offline either. The document ends up as chrome-error://chromewebdata/,
+      // so "element(s) not found" was literal: there was no app on the page.
+      //
+      // That made this a test of cold-starting with no network, which is not
+      // what "queue a message while offline" means, and it never reached the
+      // queue at all.
+      //
+      // The underlying inability to restore cached keys offline is a real
+      // product bug, tracked separately — this wait establishes the
+      // precondition, it does not paper over that.
+      const messageInput = page.locator('textarea[aria-label="Message input"]');
+      await expect(messageInput).toBeVisible({ timeout: 30000 });
+
       // ===== STEP 3: Go offline =====
       await context.setOffline(true);
 
@@ -110,8 +132,6 @@ test.describe('Offline Message Queue', () => {
 
       // ===== STEP 4: Send message while offline =====
       const testMessage = `Offline test message ${Date.now()}`;
-      const messageInput = page.locator('textarea[aria-label="Message input"]');
-      await expect(messageInput).toBeVisible({ timeout: 10000 });
       await messageInput.fill(testMessage);
 
       const sendButton = page.getByRole('button', { name: /send/i });
@@ -159,6 +179,13 @@ test.describe('Offline Message Queue', () => {
       await dismissCookieBanner(page);
       await completeEncryptionSetup(page);
       await dismissReAuthModal(page);
+
+      // Same precondition as T146: the thread must render before the network
+      // is cut, or the app cannot restore its keys and redirects to a route
+      // that cannot load offline. See the comment in T146.
+      await expect(
+        page.locator('textarea[aria-label="Message input"]')
+      ).toBeVisible({ timeout: 30000 });
 
       // ===== STEP 2: Go offline =====
       await context.setOffline(true);

--- a/tests/e2e/tests/mobile-touch-targets.spec.ts
+++ b/tests/e2e/tests/mobile-touch-targets.spec.ts
@@ -19,19 +19,30 @@ test.describe('Touch Target Standards', () => {
   const TOLERANCE = 1; // Allow 1px tolerance for sub-pixel rendering
 
   /**
-   * COVERAGE LIMIT, learned the hard way while mutation-testing this gate.
+   * COVERAGE LIMIT — corrected. The previous version of this comment was wrong
+   * in a way that cost five red CI runs of being waved off.
    *
-   * It measures only what is VISIBLE at 390px in the current auth state, which
-   * is narrower than it looks. Two mutations that should have turned it red did
-   * not, and neither was a gate defect:
+   * It claimed the gate runs "signed out", citing a mutation that survived
+   * because `{user && ...}` did not render. That is true LOCALLY when the
+   * storage state is empty, and false in CI: `playwright.config.ts:107-112`
+   * gives every project `storageState: fixtures/storage-state-auth.json`, so
+   * CI measures the SIGNED-IN tree. Reading the stale note, a real failure
+   * ("Sign Out": 26px) looked like a known blind spot instead of a finding.
    *
-   *   - a nav <Link> inside `hidden ... md:flex` — not rendered at 390px
-   *   - the messages icon inside `{user && ...}` — not rendered when signed out
+   * What is actually measured: elements VISIBLE at 390px, signed in, on `/`,
+   * with the mobile nav dropdown opened, matching the selector below.
    *
-   * So a regression in the desktop nav, or in any signed-in-only control, will
-   * not be caught here. Widening this to several viewports and both auth states
-   * is worthwhile; until then, do not read a green result as "every control in
-   * the app meets 44px".
+   * What is still NOT measured, and is genuinely blind:
+   *   - the desktop nav — `hidden ... md:flex` does not render at 390px
+   *   - the ACCOUNT dropdown — only the navigation menu is clicked, so the
+   *     second Sign Out button (GlobalNav.tsx:333) is never measured, and it
+   *     is byte-identical to the one this gate does catch
+   *   - plain anchors — excluded by the selector; menu rows are anchors, so a
+   *     26px menu row is invisible to this gate even though the WCAG 2.2
+   *     inline-link exemption does not cover menu rows
+   *   - the signed-OUT tree, which CI never exercises here
+   *
+   * Do not read green as "every control meets 44px".
    */
   test('Primary interactive elements meet 44x44px minimum on iPhone 12', async ({
     page,
@@ -48,10 +59,16 @@ test.describe('Touch Target Standards', () => {
     // likely place for a sub-44px target went unmeasured. DaisyUI dropdowns
     // open on :focus-within, and a real click is what produces that; focus()
     // alone does not reliably.
-    const menuTrigger = page.locator('[aria-label="Navigation menu"]').first();
-    if (await menuTrigger.isVisible().catch(() => false)) {
-      await menuTrigger.click();
-      await page.waitForTimeout(200);
+    // Both dropdowns, not just the nav. The account dropdown holds a Sign Out
+    // button byte-identical to the one in the nav menu; measuring only the nav
+    // left an equally-broken control shipping and untested. They are separate
+    // DaisyUI dropdowns and do not open together.
+    for (const label of ['Navigation menu', 'User account menu']) {
+      const trigger = page.locator(`[aria-label="${label}"]`).first();
+      if (await trigger.isVisible().catch(() => false)) {
+        await trigger.click();
+        await page.waitForTimeout(200);
+      }
     }
 
     // Anchors carrying `btn` are button-like and were excluded before, which

--- a/tests/e2e/utils/supabase-admin.ts
+++ b/tests/e2e/utils/supabase-admin.ts
@@ -63,6 +63,27 @@ export async function executeSQL(
     }
 
     const errorText = await response.text();
+
+    // Programming errors are ALWAYS a bug in the test, never a legitimate
+    // runtime state — and swallowing them into `[]` is indistinguishable from
+    // "the query ran and matched nothing". That is not hypothetical: a query
+    // against a non-existent `connections` table (the table is
+    // `user_connections`) returned [] for weeks, and the caller reported it as
+    // "the UI claimed success but no row was written — silent send failure".
+    // A test bug impersonated a data-loss bug and kept main red.
+    //
+    // These SQLSTATEs are fatal. Everything else (transient 5xx, permissions,
+    // exhausted retries) keeps the tolerant behaviour the 85 call sites rely
+    // on, so cleanup helpers still degrade gracefully.
+    //   42P01 undefined_table    42703 undefined_column
+    //   42601 syntax_error       42883 undefined_function
+    if (/\b(42P01|42703|42601|42883)\b/.test(errorText)) {
+      throw new Error(
+        `SQL is malformed — this is a bug in the test, not a data condition.\n` +
+          `Query: ${query}\nResponse: ${response.status} ${errorText}`
+      );
+    }
+
     console.warn(`SQL warning: ${response.status} - ${errorText}`);
     return [];
   }


### PR DESCRIPTION
E2E has been red on `main` for 5+ consecutive runs. Diagnosis found **three separate causes**, only one of which is a product defect.

| Shard | Cause | Kind |
|---|---|---|
| `msg-1/4` | test queries a table that doesn't exist | test bug — fake alarm |
| `gen-4/4` | menu rows are 26px tall | **product bug** — real WCAG 2.5.5 failure |
| `msg-3/4` | test cuts the network before the app boots | test bug — first result |

## 1. `msg-1/4` — a test bug impersonating a data-loss bug

`complete-user-workflow.spec.ts` queried `FROM connections` at `:419` and `:501`. The table is `user_connections` — migration `:699`, the RLS policies, and every `.from()` in `connection-service.ts`. `executeSQL` swallowed the resulting `42P01` into `[]`, so the test reported:

> *"The UI reported success but no connections row was written — silent send failure."*

**Nothing was losing data.** The CI log contains the swallowed error verbatim: `SQL warning: 400 - ERROR: 42P01: relation "connections" does not exist`.

Fixed both queries. Also made `executeSQL` **throw** on programming-error SQLSTATEs (`42P01`/`42703`/`42601`/`42883`) — those are always a bug in the test, never a data condition, and are otherwise indistinguishable from "matched nothing". Every other failure keeps the tolerant `[]`, so the 85 call sites (mostly cleanup helpers) still degrade gracefully instead of turning green jobs red.

## 2. `gen-4/4` — a real 26px touch target

`Sign Out` is a bare `<button>` with no `className` inside DaisyUI `.menu-sm`: `12px × 1.5` line-height + `2×4px` padding = **26px exactly**, in all three engines.

The product is **not** a regression — unmodified since the initial commit. The *gate* became able to see it in `3320b0e`, which added the menu-open click. It's doing its job.

Fixed in CSS, not markup, because:
1. There are **two** byte-identical Sign Out buttons (`GlobalNav.tsx:333` and `:441`) and the gate can only ever see one — a markup fix leaves a known-broken control shipping and untested.
2. Every *other* row in both menus is 26px too. Patching one button leaves a single 44px row among six 26px ones — worse-looking and still non-compliant.

**Verified in a real browser at 390px**, not assumed:

```
menu rows:                       26px -> 44px  (all 5)
synthetic bare <button> in li:   26px without the rule, 44px with it
horizontal overflow:             0
menu height:                     281px in an 844px viewport
```

The synthetic probe reproduces the CI failure value (`26.0px`) exactly.

## 3. `msg-3/4` — the offline test never reached the offline queue

`offline-queue.spec.ts` cut the network ~90 ms after `goto` resolved, before hydration. `messages/page.tsx:129-132` then calls `supabase.auth.getUser()` — a **network** round trip — to learn the user id, so offline it gets `null`; `restoreKeysFromSession(undefined)` never looks at the injected keys; `hasKeys()` also fails; the app redirects to `/messages/setup`, whose RSC payload can't load offline either. Final document: `chrome-error://chromewebdata/`. "element(s) not found" was **literal** — there was no app on the page.

Not a regression: msg shards 3/4 and 4/4 **never ran in any browser** until `c400c3f`. These are first results.

Added the missing precondition (wait for the thread to render) to T146 and T147. The underlying inability to restore cached keys offline is a genuine product bug, filed as **#96** — this establishes the precondition, it doesn't paper over it.

## Also: a false comment that cost five red runs

The touch-target gate's coverage note claimed it runs **signed out**. `playwright.config.ts:107-112` gives every project an authenticated `storageState`, so CI measures the **signed-in** tree. Reading that stale note, a real failure looked like a known blind spot. Corrected, and the gate now also opens the account dropdown so the second Sign Out button is covered.

## Known remaining

`offline-queue.spec.ts` **also** fails at `:425` ("failed status after max retries") — a separate assertion with an independent cause, out of scope here. **`msg-3/4` will not go green until that is diagnosed too.** Expect further first results as these specs reach code that has never executed in CI.

Local: type-check clean, lint 0 errors, 388 test files pass.

Refs #66, #76. Filed #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)