### PR TITLE
fix(messaging): stop discarding the user's message when a send fails

### DIFF
--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -47,6 +47,12 @@ function MessagesContent() {
   const [messages, setMessages] = useState<DecryptedMessage[]>([]);
   const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState(false);
+  // Set when a send fails, so MessageInput can put the text back. The token
+  // makes the same content restorable more than once.
+  const [restoreDraft, setRestoreDraft] = useState<{
+    content: string;
+    token: number;
+  } | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [cursor, setCursor] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -458,6 +464,16 @@ function MessagesContent() {
     } catch (err: unknown) {
       // Remove optimistic message on error
       setMessages((prev) => prev.filter((m) => m.id !== tempId));
+
+      // ...but give the text back. Deleting the bubble without restoring the
+      // draft is how a failed send used to destroy what the user wrote: the
+      // composer had already cleared optimistically, so the words existed
+      // nowhere. sendMessage queues the message itself when it gets far enough
+      // to encrypt it; the paths that throw before that (conversation lookup,
+      // recipient key fetch) cannot queue without writing plaintext to
+      // IndexedDB, so returning the text to the box is the fix for those.
+      setRestoreDraft({ content, token: Date.now() });
+
       const message =
         err instanceof Error
           ? err.message
@@ -648,6 +664,7 @@ function MessagesContent() {
                       conversationId={conversationId}
                       messages={messages}
                       onSendMessage={handleSendMessage}
+                      restoreDraft={restoreDraft}
                       onEditMessage={handleEditMessage}
                       onDeleteMessage={handleDeleteMessage}
                       onLoadMore={handleLoadMore}

--- a/src/components/molecular/MessageInput/MessageInput.tsx
+++ b/src/components/molecular/MessageInput/MessageInput.tsx
@@ -19,6 +19,18 @@ export interface MessageInputProps {
   className?: string;
   /** Forward ref for textarea element */
   inputRef?: React.RefObject<HTMLTextAreaElement | null>;
+  /**
+   * Text to put back in the box after a send failed.
+   *
+   * The input clears optimistically on send — right, because waiting for a
+   * round trip makes the composer feel broken. But when the send then fails,
+   * the user's typing was simply gone. Restoring it here is what stops a
+   * failed send from destroying what they wrote.
+   *
+   * Carries a `token` because the same text can fail twice in a row; without
+   * it the value would be unchanged and the effect would not re-fire.
+   */
+  restoreDraft?: { content: string; token: number } | null;
 }
 
 /**
@@ -44,6 +56,7 @@ export default function MessageInput({
   onTypingChange,
   className = '',
   inputRef,
+  restoreDraft = null,
 }: MessageInputProps) {
   const [message, setMessage] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -58,6 +71,21 @@ export default function MessageInput({
   // closure over the initial prop value)
   const onTypingChangeRef = useRef(onTypingChange);
   onTypingChangeRef.current = onTypingChange;
+
+  // Put the text back after a failed send. Keyed on the token so the same
+  // content failing twice still restores the second time.
+  //
+  // Only restores into an EMPTY box: if the user has already started typing
+  // something new, silently overwriting it would be a worse bug than the one
+  // this fixes. That case is rare — the failure usually arrives while the box
+  // is still empty from the optimistic clear.
+  const restoreTokenRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!restoreDraft) return;
+    if (restoreTokenRef.current === restoreDraft.token) return;
+    restoreTokenRef.current = restoreDraft.token;
+    setMessage((current) => (current === '' ? restoreDraft.content : current));
+  }, [restoreDraft]);
 
   const charCount = message.length;
   const charLimit = MESSAGE_CONSTRAINTS.MAX_LENGTH;

--- a/src/components/organisms/ChatWindow/ChatWindow.tsx
+++ b/src/components/organisms/ChatWindow/ChatWindow.tsx
@@ -17,6 +17,8 @@ export interface ChatWindowProps {
   messages: DecryptedMessage[];
   /** Callback to send a new message */
   onSendMessage: (content: string) => void;
+  /** Text to restore into the composer after a send failed (see MessageInput) */
+  restoreDraft?: { content: string; token: number } | null;
   /** Callback to edit a message */
   onEditMessage?: (messageId: string, newContent: string) => Promise<void>;
   /** Callback to delete a message */
@@ -59,6 +61,7 @@ export default function ChatWindow({
   conversationId,
   messages,
   onSendMessage,
+  restoreDraft = null,
   onEditMessage,
   onDeleteMessage,
   onLoadMore,
@@ -198,6 +201,7 @@ export default function ChatWindow({
       <div className="border-base-300 bg-base-100 border-t px-4 pt-4 pb-6">
         <MessageInput
           onSend={onSendMessage}
+          restoreDraft={restoreDraft}
           disabled={isBlocked}
           sending={sending}
           onTypingChange={onTypingChange}

--- a/src/services/messaging/__tests__/message-service.test.ts
+++ b/src/services/messaging/__tests__/message-service.test.ts
@@ -406,6 +406,130 @@ describe('MessageService', () => {
       });
     });
 
+    /**
+     * Fetch-failure classification had NO unit coverage before this — the only
+     * test touching the queue flipped `navigator.onLine`, which exercises the
+     * early-return at the top of sendMessage and never reaches the predicates.
+     * The bug these pin (a network fault while the browser still reports
+     * online) was invisible to the whole suite.
+     *
+     * The envelope below is the real one: postgrest-js does not throw on a
+     * failed fetch, it RESOLVES `{ data: null, status: 0, error: { message,
+     * code: '' } }`. Note every pre-existing mock in this file omits `status`,
+     * so simulating this correctly means setting it explicitly.
+     */
+    const mockInsertFailure = (insertError: Record<string, unknown>) => {
+      mockMsgClient.from.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    participant_1_id: mockUserId,
+                    participant_2_id: mockOtherUserId,
+                    is_group: false,
+                  },
+                  error: null,
+                }),
+              }),
+            }),
+            update: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          };
+        }
+        if (table === 'user_encryption_keys') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: { public_key: otherPublicKeyJwk },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'messages') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    single: vi
+                      .fn()
+                      .mockResolvedValue({ data: { sequence_number: 5 } }),
+                  }),
+                }),
+              }),
+            }),
+            insert: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  count: null,
+                  status: insertError.code === '' ? 0 : 400,
+                  statusText: '',
+                  error: insertError,
+                }),
+              }),
+            }),
+          };
+        }
+        return { select: vi.fn() };
+      });
+    };
+
+    // Each engine words an aborted fetch differently. WebKit's "Load failed"
+    // matched neither substring the code originally looked for, so on Safari
+    // the retry AND queue paths were both dead.
+    const ENGINE_WORDINGS = [
+      ['Chromium', 'TypeError: Failed to fetch'],
+      ['Firefox', 'TypeError: NetworkError when attempting to fetch resource.'],
+      ['WebKit', 'TypeError: Load failed'],
+    ] as const;
+
+    for (const [engine, message] of ENGINE_WORDINGS) {
+      it(`queues the message when the fetch fails (${engine} wording)`, async () => {
+        mockInsertFailure({ message, details: '', hint: '', code: '' });
+
+        const result = await messageService.sendMessage({
+          conversation_id: mockConversationId,
+          content: 'should survive a dropped connection',
+        });
+
+        expect(result.queued).toBe(true);
+        expect(offlineQueueService.queueMessage).toHaveBeenCalled();
+      }, 20000);
+    }
+
+    it('does NOT queue a database rejection, even if its text says "network"', async () => {
+      // The predicate matches 'network' anywhere in the message, which is safe
+      // today only because no schema identifier is named for a network. This
+      // pins the structural guard instead: a real rejection always carries a
+      // SQLSTATE, a fetch failure carries code: ''. Without the guard — and
+      // without threading the original through as `cause` — this constraint
+      // name would be read as a dropped connection and the user's message
+      // silently queued, with no error shown at all.
+      mockInsertFailure({
+        message:
+          'new row for relation "messages" violates check constraint "check_network_id"',
+        details: '',
+        hint: '',
+        code: '23514',
+      });
+
+      await expect(
+        messageService.sendMessage({
+          conversation_id: mockConversationId,
+          content: 'should surface an error, not vanish into the queue',
+        })
+      ).rejects.toThrow();
+
+      expect(offlineQueueService.queueMessage).not.toHaveBeenCalled();
+    }, 20000);
+
     it('should throw ValidationError when recipient has no encryption keys', async () => {
       vi.mocked(keyManagementService.getUserPublicKey).mockResolvedValue(null);
 

--- a/src/services/messaging/message-service.ts
+++ b/src/services/messaging/message-service.ts
@@ -65,11 +65,6 @@ function isRLSError(error: unknown): boolean {
 }
 
 /**
- * Detect transient fetch/network errors that should be retried.
- * Under CI load, Supabase REST API can timeout with TypeError("Failed to fetch").
- * These are NOT RLS errors (no .code property) but are equally transient.
- */
-/**
  * Does this message describe a failed fetch, in ANY engine?
  *
  * The three engines word it differently, and missing one silently disables
@@ -89,6 +84,11 @@ function looksLikeFetchFailure(message: string): boolean {
   );
 }
 
+/**
+ * Detect transient fetch/network errors that should be retried.
+ * Under CI load, Supabase REST API can time out at the fetch layer. These are
+ * NOT RLS errors (no .code property) but are equally transient.
+ */
 function isTransientFetchError(error: unknown): boolean {
   // Both branches share one predicate. They used to differ — the TypeError
   // branch matched 'fetch'/'network' while the object branch matched the

--- a/src/services/messaging/message-service.ts
+++ b/src/services/messaging/message-service.ts
@@ -69,15 +69,36 @@ function isRLSError(error: unknown): boolean {
  * Under CI load, Supabase REST API can timeout with TypeError("Failed to fetch").
  * These are NOT RLS errors (no .code property) but are equally transient.
  */
+/**
+ * Does this message describe a failed fetch, in ANY engine?
+ *
+ * The three engines word it differently, and missing one silently disables
+ * every retry/queue path on that browser:
+ *   Chromium  "TypeError: Failed to fetch"
+ *   Firefox   "TypeError: NetworkError when attempting to fetch resource."
+ *   WebKit    "TypeError: Load failed"          <-- matches neither of the
+ *                                                   substrings used before
+ * Kept as one predicate so a fourth wording only has to be added once.
+ */
+function looksLikeFetchFailure(message: string): boolean {
+  const msg = message.toLowerCase();
+  return (
+    msg.includes('fetch') ||
+    msg.includes('network') ||
+    msg.includes('load failed')
+  );
+}
+
 function isTransientFetchError(error: unknown): boolean {
+  // Both branches share one predicate. They used to differ — the TypeError
+  // branch matched 'fetch'/'network' while the object branch matched the
+  // narrower 'failed to fetch'/'networkerror' — and neither covered WebKit.
   if (error instanceof TypeError) {
-    const msg = error.message.toLowerCase();
-    return msg.includes('fetch') || msg.includes('network');
+    return looksLikeFetchFailure(error.message);
   }
   if (!error || typeof error !== 'object') return false;
   const err = error as Record<string, unknown>;
-  const msg = typeof err.message === 'string' ? err.message.toLowerCase() : '';
-  return msg.includes('failed to fetch') || msg.includes('networkerror');
+  return typeof err.message === 'string' && looksLikeFetchFailure(err.message);
 }
 
 /**
@@ -88,11 +109,34 @@ function isNetworkError(error: unknown): boolean {
   // `onLine`, so the old guard passed on the server and `!undefined` made
   // EVERY error look like a network error during SSR.
   if (typeof window !== 'undefined' && !window.navigator.onLine) return true;
-  if (error instanceof TypeError) {
-    const msg = error.message.toLowerCase();
-    return msg.includes('fetch') || msg.includes('network');
-  }
-  return false;
+
+  // Delegate rather than re-implement. This used to test only
+  // `error instanceof TypeError`, while its sibling also matched an object
+  // whose `.message` names a fetch failure — and that gap silently discarded
+  // users' messages.
+  //
+  // supabase-js never throws on a failed fetch: postgrest-js catches it and
+  // RETURNS `{ error: { message: "TypeError: Failed to fetch", ... }, status: 0 }`
+  // (PostgrestBuilder, the `.catch` on the response promise). So when the
+  // network drops while `navigator.onLine` is still true — a captive portal, a
+  // dropped tunnel, a proxy 500ing — the INSERT sees that object,
+  // isTransientFetchError sends it into the RLS-retry loop, the retry aborts
+  // too, and because the retry error has no `.code` and is not an RLS error it
+  // throws `ConnectionError("Failed to send message: <fetch error>")` on the
+  // FIRST inner retry — about two seconds in, not after the retry budget is
+  // spent.
+  //
+  // That ConnectionError is not a TypeError, so the old check returned false,
+  // the message was never queued, and messages/page.tsx then deleted the
+  // optimistic bubble in its catch — the user's typed text vanished with only
+  // an error banner. The offline queue exists precisely for this case and was
+  // unreachable in it.
+  //
+  // isTransientFetchError matches on `.message`, so it recognises both the raw
+  // object and the wrapped ConnectionError. Keeping one implementation means
+  // "should we retry this?" and "should we queue this?" cannot drift apart
+  // again.
+  return isTransientFetchError(error);
 }
 
 export class MessageService {

--- a/src/services/messaging/message-service.ts
+++ b/src/services/messaging/message-service.ts
@@ -97,7 +97,38 @@ function isTransientFetchError(error: unknown): boolean {
     return looksLikeFetchFailure(error.message);
   }
   if (!error || typeof error !== 'object') return false;
+
+  // Judge the ORIGINAL, not the wrapper. The send path wraps failures as
+  // `ConnectionError("Failed to send message: " + original.message, original)`,
+  // which concatenates the database's own text into the wrapper — so string
+  // matching the wrapper would happily find 'network' inside a constraint name
+  // and undo the code gate below. Following `cause` keeps the gate effective
+  // after wrapping.
+  if (error instanceof Error && error.cause) {
+    return isTransientFetchError(error.cause);
+  }
+
   const err = error as Record<string, unknown>;
+
+  // A PostgREST/Postgres rejection ALWAYS carries a code — a SQLSTATE like
+  // '23505', or a 'PGRST***'. A fetch-layer failure carries `code: ''` and
+  // `status: 0` (postgrest-js builds that envelope in its response .catch).
+  // So a non-empty code proves the server answered and refused us, which is
+  // never a transport failure no matter what the message happens to contain.
+  //
+  // Without this gate the predicate is correct only by naming coincidence: it
+  // matches 'fetch'/'network' ANYWHERE in the message, and nothing stops a
+  // future migration adding, say, a `check_network_*` constraint or a
+  // `network_id` column — whose violation message would then be classified as
+  // a network failure and silently queued. That failure mode is nasty:
+  // `queued: true` shows no error banner at all, the optimistic bubble sits
+  // there looking sent, and useOfflineQueue polls every 3s forever because
+  // failed rows never clear queueCount.
+  //
+  // Checked at time of writing: no identifier in the schema contains 'network'
+  // or 'fetch'. This makes that a guarantee instead of a coincidence.
+  if (typeof err.code === 'string' && err.code !== '') return false;
+
   return typeof err.message === 'string' && looksLikeFetchFailure(err.message);
 }
 
@@ -282,6 +313,25 @@ export class MessageService {
 
       if (convError || !conversation) {
         logStep(`4-conversation-FAIL: ${convError?.message || 'no data'}`);
+
+        // Do not blame the conversation for a network fault. This lookup sits
+        // OUTSIDE the inner try that owns the offline-queue decision, so a
+        // fetch failure here used to surface as "Conversation not found" — a
+        // confident, wrong diagnosis — and messages/page.tsx then deleted the
+        // user's optimistic bubble.
+        //
+        // The message is not queued here on purpose: it has not been encrypted
+        // yet (encryption needs the recipient key fetched further down), so
+        // queuing would write PLAINTEXT to IndexedDB. That is the exposure in
+        // GHSA-94f4-7f3v-g4g5, and widening a live security finding to fix a
+        // UX bug is the wrong trade. The page keeps the text in the composer
+        // instead, so nothing is lost and nothing is persisted in the clear.
+        if (isTransientFetchError(convError)) {
+          throw new ConnectionError(
+            'Could not reach the server. Check your connection and try again.',
+            convError
+          );
+        }
         throw new ValidationError('Conversation not found', 'conversation_id');
       }
       logStep('4-conversation-ok');
@@ -461,8 +511,13 @@ export class MessageService {
 
               if (retryErr.code === '23505') continue;
               if (!isRLSError(retryErr)) {
+                // Carry the original as `cause`. The queue decision downstream
+                // needs the PostgREST `code` to tell a dead socket from a
+                // server rejection, and concatenating the message into a
+                // wrapper throws that away.
                 throw new ConnectionError(
-                  'Failed to send message: ' + retryErr.message
+                  'Failed to send message: ' + retryErr.message,
+                  retryErr
                 );
               }
             }
@@ -475,7 +530,8 @@ export class MessageService {
 
           // Non-retryable error or retries exhausted
           throw new ConnectionError(
-            'Failed to send message: ' + insertError.message
+            'Failed to send message: ' + insertError.message,
+            insertError
           );
         }
 
@@ -554,6 +610,14 @@ export class MessageService {
       if (
         error instanceof AuthenticationError ||
         error instanceof ValidationError ||
+        // ConnectionError must pass through, not be rewrapped. It is what the
+        // conversation lookup and getUserPublicKey throw on a network fault,
+        // and both of those sit outside the inner try that owns the queue
+        // decision. Rewrapping them as a generic EncryptionError("Failed to
+        // send message") discarded the fact that the network was the cause —
+        // so the UI could not tell a transport problem from a crypto one, and
+        // the user got a misleading error on top of a deleted message.
+        error instanceof ConnectionError ||
         error instanceof EncryptionError ||
         error instanceof EncryptionLockedError
       ) {

--- a/tests/e2e/messaging/offline-queue.spec.ts
+++ b/tests/e2e/messaging/offline-queue.spec.ts
@@ -449,7 +449,15 @@ test.describe('Offline Message Queue', () => {
     }
   });
 
-  test('should show failed status after max retries', async ({ browser }) => {
+  // Renamed: the old name ("should show failed status after max retries")
+  // promised a failed-message status UI that does not exist — MessageBubble has
+  // no status handling and DecryptedMessage has no status field. What this
+  // actually asserts, and what matters, is that the message is not silently
+  // discarded when the send fails. It goes to the offline queue instead
+  // (QueueStatusIndicator, mounted at ChatWindow.tsx:179, surfaces it).
+  test('should keep the message when the network fails mid-send', async ({
+    browser,
+  }) => {
     test.setTimeout(180000);
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -468,9 +476,13 @@ test.describe('Offline Message Queue', () => {
       await dismissReAuthModal(page);
 
       // ===== STEP 2: Intercept API and always fail =====
-      let interceptCount = 0;
+      //
+      // Count POSTs only. The pattern also matches the GET that the 10s
+      // polling refetch issues, so a plain counter reached >= 1 without a
+      // single send ever being attempted — the assertion below was vacuous.
+      let sendAttempts = 0;
       await page.route('**/rest/v1/messages*', async (route) => {
-        interceptCount++;
+        if (route.request().method() === 'POST') sendAttempts++;
         await route.abort('failed');
       });
 
@@ -482,12 +494,17 @@ test.describe('Offline Message Queue', () => {
       const sendButton = page.getByRole('button', { name: /send/i });
       await sendButton.click();
 
-      // ===== STEP 4: Wait for retries to exhaust =====
-      await page.waitForTimeout(35000);
+      // ===== STEP 4: Wait for the send to fail and be queued =====
+      //
+      // Was 35s "for retries to exhaust". They never exhaust on this path: the
+      // INSERT aborts, the RLS-retry loop sleeps ~2s, the retry aborts too, and
+      // since that error has no `.code` and is not an RLS error the send throws
+      // right there. The outcome is settled ~2s after the click, so the extra
+      // 33s was dead time on every run, in every browser.
+      await page.waitForTimeout(10000);
 
-      // ===== STEP 5: Verify message was attempted and failed gracefully =====
-      // The system should have tried to send multiple times
-      expect(interceptCount).toBeGreaterThanOrEqual(1);
+      // ===== STEP 5: Verify the send was attempted and the message survived =====
+      expect(sendAttempts).toBeGreaterThanOrEqual(1);
 
       // Message should still be visible in the UI (not lost)
       await expect(page.getByText(testMessage)).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
The last deterministic E2E failure (`offline-queue.spec.ts`, shard `msg-3/4`, 100% of runs). **It is a real product bug, not a test bug.**

A message that fails to send because of a network-layer fault — while the browser still reports `navigator.onLine === true` — is silently thrown away.

From the failing CI trace (run `30845792628`):

```
[sendMessage] INSERT failed {error: Failed to send message: TypeError: Failed to fetch}
```

Zero `offline-queue-updated` events. The failure screenshot shows the thread reading **"No messages yet. Send the first one!"** with the composer cleared. The user's typed text is gone — not queued, not recoverable, not even an error banner.

## Root cause: two sibling predicates disagreed

| | matched a thrown `TypeError` | matched an error **object** |
|---|---|---|
| `isTransientFetchError` | ✅ | ✅ |
| `isNetworkError` | ✅ | ❌ |

supabase-js **never throws** on a failed fetch — postgrest-js catches it and *returns* `{ error: { message: "TypeError: Failed to fetch", … }, status: 0 }`.

So the INSERT gets an error **object**. `isTransientFetchError` recognises it and enters the RLS-retry loop; the retry aborts too, and since that error has no `.code` and isn't an RLS error, the send throws `ConnectionError` ~2s in. `isNetworkError` then sees a `ConnectionError` — not a `TypeError` — with `onLine` still true, returns false, and **the offline queue, which exists for exactly this case, is never reached**. `messages/page.tsx:458-460` then deletes the optimistic bubble.

`isNetworkError` now delegates to `isTransientFetchError`, so the two cannot drift apart again.

## Also fixes a pre-existing browser gap

Both predicates only looked for `'fetch'`/`'network'`/`'failed to fetch'`. The engines word it differently:

```
Chromium  "TypeError: Failed to fetch"
Firefox   "TypeError: NetworkError when attempting to fetch resource."
WebKit    "TypeError: Load failed"        ← matched NEITHER
```

On WebKit `isTransientFetchError` already returned false **today**, skipping the retry path entirely. Both branches now share one `looksLikeFetchFailure` covering all three. Without this the webkit shard would have stayed red.

## Test corrections in the same file

- **Renamed** from *"should show failed status after max retries"*. There is no failed-status UI — `MessageBubble` has no status handling, `DecryptedMessage` has no status field. What it actually asserts is that the message survives.
- **`expect(interceptCount).toBeGreaterThanOrEqual(1)` was vacuous** — the route pattern also catches the GET from the 10s polling refetch, so the counter climbed even when no send occurred. Counts POSTs now.
- **The 35s "wait for retries to exhaust" was fiction.** Retries never exhaust on this path; the outcome is settled ~2s after the click. Reduced to 10s, removing ~25s of dead time per run per browser.

## Verification

Diagnosis was adversarially reviewed by three independent agents across control-flow, supabase-client and UI/test-validity lenses. **All three failed to refute it.** Their corrections are incorporated: the throw site is the first inner retry (not retry exhaustion), the WebKit wording gap, and the vacuous assertion.

One reviewer confirmed the chain against the actual CI trace rather than statically — including the 2000 ms gap matching the retry loop's `Math.min(2000 * 2^0, 16000)` backoff.

Local: type-check clean, lint 0 errors, 388 test files pass.

## Follow-up worth doing

postgrest-js sets `status: 0` on every fetch-layer failure in **every** engine — a stronger signal than matching message text. Using it means capturing the status at the INSERT site rather than re-deriving intent from a stringified wrapper two frames later. Not done here because it changes the send path's shape; the string predicate is now centralised in one function so a fourth engine wording is a one-line change.

Refs #66, #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)